### PR TITLE
fix JSON_EXTRACT issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 CHANGELOG - Ensembl Prodinf MasterDB
 ====================================
+1.2.3
+-----
+- Reverted  to django-jsonfield, JSON_EXRACT is not supported for mysql
+
 1.2.2
 -----
 - Fixed filtering on db_types for Biotype and MetaKey

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django~=3.2.2
+django-jsonfield~=1.4.1
 django-multiselectfield~=0.1.12
 djangorestframework~=3.12.2
 django-rest-swagger~=2.2.0

--- a/src/ensembl/production/masterdb/models.py
+++ b/src/ensembl/production/masterdb/models.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.template.defaultfilters import truncatechars
 from multiselectfield import MultiSelectField
+import jsonfield.fields
 
 from ensembl.production.djcore.models import NullTextField, BaseTimestampedModel, HasCurrent, HasDescription
 from ensembl.production.djcore.fields import EnumField
@@ -42,7 +43,7 @@ DB_TYPE_CHOICES_METAKEY = (('cdna', 'cdna'),
 
 class WebData(BaseTimestampedModel, HasDescription):
     web_data_id = models.AutoField(primary_key=True)
-    data = models.JSONField(null=True)
+    data = jsonfield.JSONField(null=True)
     comment = NullTextField(trim_cr=True)
     description = models.CharField(max_length=255, blank=True, null=True)
 

--- a/src/ensembl/production/masterdb/tests.py
+++ b/src/ensembl/production/masterdb/tests.py
@@ -391,7 +391,7 @@ class AnalysisTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         analysis = AnalysisDescription.objects.get(logic_name='testwebtestdata5')
         self.assertEqual(analysis.web_data.data, json.loads('{"default": "normalupdated"}'))
-        self.assertEqual(WebData.objects.filter(data__default="normalupdated").count(), 1)
+        self.assertEqual(WebData.objects.filter(data__contains="normalupdated").count(), 1)
 
     def testWebDataCreateUpdate(self):
         valid_payload = {


### PR DESCRIPTION
Fix for django.db.utils.OperationalError: (1305, 'FUNCTION ensembl_production.JSON_EXTRACT does not exist)
native models.JSON_FEILD in Django does not directly support the JSON_EXTRACT function in MySQL.json search
revert to the jsonfield.fields for web data fixed this issue 
  